### PR TITLE
include laravel 10 and 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/database": "^8.0|^9.0",
-        "illuminate/support": "^8.0|^9.0",
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
         "laravel/helpers": "^1.0"
     },
     "license": "MIT",


### PR DESCRIPTION
It looks like we can bring support for laravel 10 and 11 just by bumping the compose dependencies.